### PR TITLE
issue 3: get docker release up and running

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: get product version
         id: get-product-version
         run: |
@@ -32,7 +32,7 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: 'Checkout directory'
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
@@ -40,7 +40,7 @@ jobs:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -57,7 +57,7 @@ jobs:
     name: Go linux ${{ matrix.arch }} build
 
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Setup go
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
@@ -72,7 +72,7 @@ jobs:
           mkdir dist out
           make build
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip dist/
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
           path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
@@ -91,7 +91,7 @@ jobs:
       version: ${{needs.get-product-version.outputs.product-version}}
 
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
 
-      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -72,7 +72,7 @@ jobs:
           mkdir dist out
           make build
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip dist/
-      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
           path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: 'Checkout directory'
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+# Creates a GitHub Release.
+# Workflow is manually run.
+# Preselect branch or tag before running this workflow.
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      # Defaults to publishing draft releases.
+      # Review draft before formally releasing!
+      draft:
+        description: "Create a release draft"
+        required: false
+        default: true
+        type: boolean
+      prerelease:
+        description: "Mark this release as a prerelease"
+        required: false
+        default: "auto"
+        type: choice
+        # auto follows semver. Prerelease versions are hyphenated with a label. ex. 0.0.0-alpha, 1.0.0-rc1
+        options:
+          - auto
+          - "true"
+          - "false"
+      make-latest:
+        description: "Latest release"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: self-hosted
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required by GoRelease
+
+      - name: Golang Setup
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          check-latest: true
+
+      - name: go-check
+        run: go version
+
+        # Supports Buildx
+      - name: Qemu Setup
+        uses: docker/setup-qemu-action@v3
+
+      - name: Buildx Setup
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cosign Install
+        uses: sigstore/cosign-installer@v3
+
+      - name: GPG Import
+        id: gpg-import
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSWORD }}
+
+      - name: Cache Setup
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./dist/**
+          key: ${{ github.ref }}
+
+      - name: "Docker Login: ghcr.io"
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Docker Login: docker.io"
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: "Docker Login: quay.io"
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+        # Needed for nPFM
+      - name: Create GPG Signing Key File
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          GPG_KEY_FILE=/tmp/signing-key.gpg
+          echo "${{ secrets.GPG_PRIVATE_KEY_BASE64 }}" | base64 -di > "${GPG_KEY_FILE}"
+          echo "GPG_KEY_FILE=${GPG_KEY_FILE}" >> "${GITHUB_ENV}"
+        env:
+          GPG_TTY: /dev/ttys000 # Set the GPG_TTY to avoid issues with pinentry
+
+      - name: "GoReleaser: Release"
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --timeout=60m --verbose --debug
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.gpg-import.outputs.fingerprint }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GITHUB_RELEASE_PRERELEASE: ${{ inputs.prerelease }}
+          GITHUB_RELEASE_MAKE_LATEST: ${{ inputs.make-latest }}
+          NFPM_DEFAULT_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
+
+      - name: Remove GPG Signing Key File
+        if: always()
+        run: |
+          if [ -n "${GPG_KEY_FILE}" ]; then
+            rm -rf "${GPG_KEY_FILE}"
+          fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,9 +3,9 @@ name: Tests
 on: [push, workflow_dispatch, pull_request]
 
 env:
-  KIND_VERSION: "v0.19.0"
-  BATS_VERSION: "1.9.0"
-  NODE_VERSION: "19.8.1"
+  KIND_VERSION: "v0.23.0"
+  BATS_VERSION: "1.11.0"
+  NODE_VERSION: "19.9.0"
   TARBALL_FILE: openbao-csi-provider.docker.tar
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,7 +75,7 @@ jobs:
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
           version: ${{ env.KIND_VERSION }}
 
-      - uses: actions/download-artifact@ #65a9edc5881444af0b9093a5e628f2fe47ea3b2e v4.1.7
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: openbao-csi-provider-image
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: .go-version
@@ -30,7 +30,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: .go-version
@@ -43,7 +43,7 @@ jobs:
       - name: Test
         run: make test
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: openbao-csi-provider-image
           path: ${{ env.TARBALL_FILE }}
@@ -58,7 +58,7 @@ jobs:
         kind-k8s-version: [1.27.13, 1.28.9, 1.29.4]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -68,14 +68,14 @@ jobs:
         shell: bash
 
       - name: Create Kind Cluster
-        uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
           cluster_name: kind
           config: test/bats/configs/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
           version: ${{ env.KIND_VERSION }}
 
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@ #65a9edc5881444af0b9093a5e628f2fe47ea3b2e v4.1.7
         with:
           name: openbao-csi-provider-image
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,4 +83,4 @@ jobs:
         run: docker image load --input ${{ env.TARBALL_FILE }}
 
       - name: bats tests
-        run: DISPLAY_SETUP_TEARDOWN_LOGS=true make e2e-teardown e2e-setup e2e-test
+        run: DISPLAY_SETUP_TEARDOWN_LOGS=true make e2e-setup e2e-test e2e-teardown

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,4 +83,5 @@ jobs:
         run: docker image load --input ${{ env.TARBALL_FILE }}
 
       - name: bats tests
+        timeout-minutes: 15
         run: DISPLAY_SETUP_TEARDOWN_LOGS=true make e2e-setup e2e-test e2e-teardown

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,15 +3,11 @@
 
 schema = "1"
 
-project "vault-csi-provider" {
-  team = "vault"
-  slack {
-    // #vault-releases channel
-    notification_channel = "C03RXFX5M4L" // #feed-vault-releases
-  }
+project "openbao-csi-provider" {
+  team = "openbao"
   github {
-    organization = "hashicorp"
-    repository = "vault-csi-provider"
+    organization = "openbao"
+    repository = "openbao-csi-provider"
     release_branches = ["main"]
   }
 }
@@ -24,8 +20,8 @@ event "merge" {
 event "build" {
   depends = ["merge"]
   action "build" {
-    organization = "hashicorp"
-    repository = "vault-csi-provider"
+    organization = "openbao"
+    repository = "openbao-csi-provider"
     workflow = "build"
   }
 }
@@ -33,7 +29,7 @@ event "build" {
 event "upload-dev" {
   depends = ["build"]
   action "upload-dev" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "upload-dev"
     depends = ["build"]
@@ -47,7 +43,7 @@ event "upload-dev" {
 event "security-scan-binaries" {
   depends = ["upload-dev"]
   action "security-scan-binaries" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "security-scan-binaries"
     config = "security-scan.hcl"
@@ -61,7 +57,7 @@ event "security-scan-binaries" {
 event "security-scan-containers" {
   depends = ["security-scan-binaries"]
   action "security-scan-containers" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "security-scan-containers"
     config = "security-scan.hcl"
@@ -75,7 +71,7 @@ event "security-scan-containers" {
 event "sign" {
   depends = ["security-scan-containers"]
   action "sign" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "sign"
   }
@@ -88,7 +84,7 @@ event "sign" {
 event "verify" {
   depends = ["sign"]
   action "verify" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "verify"
   }
@@ -109,7 +105,7 @@ event "trigger-staging" {
 event "promote-staging" {
   depends = ["trigger-staging"]
   action "promote-staging" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "promote-staging"
     config = "release-metadata.hcl"
@@ -123,7 +119,7 @@ event "promote-staging" {
 event "promote-staging-docker" {
   depends = ["promote-staging"]
   action "promote-staging-docker" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "promote-staging-docker"
   }
@@ -141,7 +137,7 @@ event "trigger-production" {
 event "promote-production" {
   depends = ["trigger-production"]
   action "promote-production" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "promote-production"
   }
@@ -154,7 +150,7 @@ event "promote-production" {
 event "promote-production-docker" {
   depends = ["promote-production"]
   action "promote-production-docker" {
-    organization = "hashicorp"
+    organization = "openbao"
     repository = "crt-workflows-common"
     workflow = "promote-production-docker"
   }

--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-url_docker_registry_dockerhub = "https://registry.hub.docker.com/r/hashicorp/vault-csi-provider"
-url_license = "https://github.com/hashicorp/vault-csi-provider/blob/main/LICENSE"
-url_project_website = "https://www.vaultproject.io/docs/platform/k8s/csi"
-url_source_repository = "https://github.com/hashicorp/vault-csi-provider"
+url_docker_registry_dockerhub = "https://registry.hub.docker.com/r/openbao/openbao-csi-provider"
+url_license = "https://github.com/openbao/openbao-csi-provider/blob/main/LICENSE"
+url_project_website = "https://www.openbaoproject.io/docs/platform/k8s/csi"
+url_source_repository = "https://github.com/openbao/openbao-csi-provider"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 REGISTRY_NAME?=quay.io/openbao
 IMAGE_NAME=openbao-csi-provider
 VERSION?=0.0.0-dev
-IMAGE_TAG=$(IMAGE_NAME):$(VERSION)
-IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
+IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
+# commented because it may not be in use
+# IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
 # https://reproducible-builds.org/docs/source-date-epoch/
 DATE_FMT=+%Y-%m-%d-%H:%M
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ e2e-setup:
 		--namespace=csi \
 		--values=test/bats/configs/openbao/openbao.values.yaml \
 		$(OPENBAO_VERSION_ARGS)
-	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=openbao
+	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=openbao || kubectl describe pods -l app.kubernetes.io/name=openbao
 	kubectl exec -i --namespace=csi openbao-0 -- /bin/sh /mnt/bootstrap/bootstrap.sh
 	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=openbao-csi-provider
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY_NAME?=quay.io/openbao
 IMAGE_NAME=openbao-csi-provider
 VERSION?=0.0.0-dev
-IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
+IMAGE_TAG=$(IMAGE_NAME):$(VERSION)
 IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
 # https://reproducible-builds.org/docs/source-date-epoch/
 DATE_FMT=+%Y-%m-%d-%H:%M
@@ -17,7 +17,7 @@ LDFLAGS?="-X '$(PKG).BuildVersion=$(VERSION)' \
 	-X '$(PKG).GoVersion=$(shell go version)'"
 CSI_DRIVER_VERSION=1.3.2
 OPENBAO_HELM_VERSION=0.4.0
-OPENBAO_VERSION=v2.0.0-alpha20240329
+OPENBAO_VERSION=2.0.0-alpha20240329
 GOLANGCI_LINT_FORMAT?=colored-line-number
 
 OPENBAO_VERSION_ARGS=--set server.image.tag=$(OPENBAO_VERSION)
@@ -75,7 +75,8 @@ e2e-setup:
 	kind load docker-image e2e/openbao-csi-provider:latest
 	kubectl apply -f test/bats/configs/cluster-resources.yaml
 	helm install secrets-store-csi-driver secrets-store-csi-driver \
-		--repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts --version=$(CSI_DRIVER_VERSION) \
+		--repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts \
+		--version=$(CSI_DRIVER_VERSION) \
 		--wait --timeout=5m \
 		--namespace=csi \
 		--set linux.image.pullPolicy="IfNotPresent" \
@@ -84,7 +85,8 @@ e2e-setup:
 	helm install openbao-bootstrap test/bats/configs/openbao \
 		--namespace=csi
 	helm install openbao openbao \
-		--repo https://openbao.github.io/openbao-helm --version=$(OPENBAO_HELM_VERSION) \
+		--repo https://openbao.github.io/openbao-helm \
+		--version=$(OPENBAO_HELM_VERSION) \
 		--wait --timeout=5m \
 		--namespace=csi \
 		--values=test/bats/configs/openbao/openbao.values.yaml \
@@ -105,7 +107,7 @@ e2e-test:
 mod:
 	@go mod tidy
 
-promote-staging-manifest: #promote staging manifests to release dir
+promote-staging-manifest: # promote staging manifests to release dir
 	@rm -rf deployment
 	@cp -r manifest_staging/deployment .
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REGISTRY_NAME?=docker.io/hashicorp
+REGISTRY_NAME?=quay.io/openbao
 IMAGE_NAME=openbao-csi-provider
 VERSION?=0.0.0-dev
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
@@ -16,16 +16,11 @@ LDFLAGS?="-X '$(PKG).BuildVersion=$(VERSION)' \
 	-X '$(PKG).BuildDate=$(BUILD_DATE)' \
 	-X '$(PKG).GoVersion=$(shell go version)'"
 CSI_DRIVER_VERSION=1.3.2
-OPENBAO_HELM_VERSION=0.3.0
+OPENBAO_HELM_VERSION=0.4.0
 OPENBAO_VERSION=v2.0.0-alpha20240329
 GOLANGCI_LINT_FORMAT?=colored-line-number
 
 OPENBAO_VERSION_ARGS=--set server.image.tag=$(OPENBAO_VERSION)
-ifdef OPENBAO_LICENSE
-	OPENBAO_VERSION_ARGS=--set server.image.repository=docker.mirror.hashicorp.services/openbao/openbao-enterprise \
-		--set server.image.tag=$(OPENBAO_VERSION)-ent \
-		--set server.enterpriseLicense.secretName=openbao-ent-license
-endif
 
 .PHONY: default build test bootstrap fmt lint image e2e-image e2e-setup e2e-teardown e2e-test mod setup-kind promote-staging-manifest copyright
 
@@ -86,9 +81,6 @@ e2e-setup:
 		--set linux.image.pullPolicy="IfNotPresent" \
 		--set syncSecret.enabled=true \
 		--set tokenRequests[0].audience="openbao"
-	@if [ -n "$(OPENBAO_LICENSE)" ]; then\
-        kubectl create --namespace=csi secret generic openbao-ent-license --from-literal="license=${OPENBAO_LICENSE}";\
-    fi
 	helm install openbao-bootstrap test/bats/configs/openbao \
 		--namespace=csi
 	helm install openbao openbao \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMAGE_NAME=openbao-csi-provider
 VERSION?=0.0.0-dev
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
 # commented because it may not be in use
-# IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
+IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
 # https://reproducible-builds.org/docs/source-date-epoch/
 DATE_FMT=+%Y-%m-%d-%H:%M
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,9 @@ e2e-setup:
 		--namespace=csi \
 		--values=test/bats/configs/openbao/openbao.values.yaml \
 		$(OPENBAO_VERSION_ARGS)
-	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=openbao || kubectl describe pods -l app.kubernetes.io/name=openbao
+	kubectl wait --namespace=csi --for=condition=Ready --timeout=3m pod -l app.kubernetes.io/name=openbao || kubectl describe pods --namespace=csi -l app.kubernetes.io/name=openbao
 	kubectl exec -i --namespace=csi openbao-0 -- /bin/sh /mnt/bootstrap/bootstrap.sh
-	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=openbao-csi-provider
+	kubectl wait --namespace=csi --for=condition=Ready --timeout=3m pod -l app.kubernetes.io/name=openbao-csi-provider || kubectl describe pods --namespace=csi -l app.kubernetes.io/name=openbao-csi-provider
 
 e2e-teardown:
 	helm uninstall --namespace=csi openbao || true

--- a/test/bats/configs/openbao-all-secretproviderclass.yaml
+++ b/test/bats/configs/openbao-all-secretproviderclass.yaml
@@ -6,7 +6,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-all
 spec:
-  provider: openbao
+  provider: vault
   parameters:
     roleName: "all-role"
     openbaoAddress: https://openbao:8200

--- a/test/bats/configs/openbao-db-secretproviderclass.yaml
+++ b/test/bats/configs/openbao-db-secretproviderclass.yaml
@@ -6,7 +6,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-db
 spec:
-  provider: openbao
+  provider: vault
   parameters:
     roleName: "db-role"
     openbaoAddress: https://openbao:8200

--- a/test/bats/configs/openbao-kv-custom-audience-secretproviderclass.yaml
+++ b/test/bats/configs/openbao-kv-custom-audience-secretproviderclass.yaml
@@ -7,7 +7,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-kv-custom-audience
 spec:
-  provider: openbao
+  provider: vault
   parameters:
     audience: custom-audience
     roleName: "kv-custom-audience-role"

--- a/test/bats/configs/openbao-kv-namespace-secretproviderclass.yaml
+++ b/test/bats/configs/openbao-kv-namespace-secretproviderclass.yaml
@@ -6,7 +6,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-kv-namespace
 spec:
-  provider: openbao
+  provider: vault
   parameters:
     roleName: "kv-namespace-role"
     openbaoAddress: https://openbao:8200

--- a/test/bats/configs/openbao-kv-secretproviderclass-jwt-auth.yaml
+++ b/test/bats/configs/openbao-kv-secretproviderclass-jwt-auth.yaml
@@ -7,7 +7,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-kv-jwt-auth
 spec:
-  provider: openbao
+  provider: vault
   parameters:
     roleName: "jwt-kv-role"
     openbaoAuthMountPath: "jwt"

--- a/test/bats/configs/openbao-kv-secretproviderclass.yaml
+++ b/test/bats/configs/openbao-kv-secretproviderclass.yaml
@@ -7,7 +7,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-kv
 spec:
-  provider: openbao
+  provider: vault
   parameters:
     roleName: "kv-role"
     objects: |

--- a/test/bats/configs/openbao-kv-sync-multiple-secretproviderclass.yaml
+++ b/test/bats/configs/openbao-kv-sync-multiple-secretproviderclass.yaml
@@ -7,7 +7,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-kv-sync-1
 spec:
-  provider: openbao
+  provider: vault
   secretObjects:
   - secretName: kvsecret-1
     type: Opaque
@@ -30,7 +30,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-kv-sync-2
 spec:
-  provider: openbao
+  provider: vault
   secretObjects:
   - secretName: kvsecret-2
     type: Opaque

--- a/test/bats/configs/openbao-kv-sync-secretproviderclass.yaml
+++ b/test/bats/configs/openbao-kv-sync-secretproviderclass.yaml
@@ -7,7 +7,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-kv-sync
 spec:
-  provider: openbao
+  provider: vault
   secretObjects:
   - secretName: kvsecret
     type: Opaque

--- a/test/bats/configs/openbao-pki-secretproviderclass.yaml
+++ b/test/bats/configs/openbao-pki-secretproviderclass.yaml
@@ -6,7 +6,7 @@ kind: SecretProviderClass
 metadata:
   name: openbao-pki
 spec:
-  provider: openbao
+  provider: vault
   parameters:
     roleName: "pki-role"
     openbaoAddress: https://openbao:8200

--- a/test/bats/configs/openbao/openbao.values.yaml
+++ b/test/bats/configs/openbao/openbao.values.yaml
@@ -26,7 +26,7 @@ server:
 
   extraEnvironmentVars:
     # Ensure that running openbao commands in the pod uses the correct CA.
-    VAULT_CACERT: /mnt/tls/ca.crt
+    BAO_CACERT: /mnt/tls/ca.crt
 
   standalone:
     enabled: true
@@ -57,6 +57,10 @@ csi:
     repository: "e2e/openbao-csi-provider"
     tag: "latest"
     pullPolicy: Never
+
+  agent:
+    image:
+      repository: openbao/openbao-ubi
 
   volumes:
   - name: openbao-client-tls

--- a/test/bats/configs/openbao/openbao.values.yaml
+++ b/test/bats/configs/openbao/openbao.values.yaml
@@ -26,7 +26,7 @@ server:
 
   extraEnvironmentVars:
     # Ensure that running openbao commands in the pod uses the correct CA.
-    OPENBAO_CACERT: /mnt/tls/ca.crt
+    VAULT_CACERT: /mnt/tls/ca.crt
 
   standalone:
     enabled: true

--- a/test/bats/configs/openbao/openbao.values.yaml
+++ b/test/bats/configs/openbao/openbao.values.yaml
@@ -10,7 +10,7 @@ injector:
 
 server:
   image:
-    repository: docker.mirror.hashicorp.services/openbao/openbao
+    repository: quay.io/openbao/openbao
   volumes:
   - name: openbao-server-tls
     secret:

--- a/test/bats/configs/openbao/openbao.values.yaml
+++ b/test/bats/configs/openbao/openbao.values.yaml
@@ -9,8 +9,6 @@ injector:
   enabled: false
 
 server:
-  image:
-    repository: quay.io/openbao/openbao
   volumes:
   - name: openbao-server-tls
     secret:

--- a/test/bats/configs/openbao/templates/bootstrap-configmap.yaml
+++ b/test/bats/configs/openbao/templates/bootstrap-configmap.yaml
@@ -11,12 +11,12 @@ metadata:
 data:
   bootstrap.sh: |-
     {
-      bao status
-      while [[ $? -ne 2 ]]; do sleep 1 && bao status; done
+      bao status -tls-skip-verify
+      while [[ $? -ne 2 ]]; do sleep 1 && bao status -tls-skip-verify; done
     } > /dev/null
-    bao operator init --key-shares=1 --key-threshold=1 > /tmp/openbao_init
+    bao operator init --key-shares=1 --key-threshold=1 -tls-skip-verify > /tmp/openbao_init
     unseal=$(cat /tmp/openbao_init | grep "Unseal Key 1: " | sed -e "s/Unseal Key 1: //g")
     root=$(cat /tmp/openbao_init | grep "Initial Root Token:" | sed -e "s/Initial Root Token: //g")
-    bao operator unseal ${unseal?} > /dev/null
-    bao login -no-print ${root?} > /dev/null
+    bao operator unseal -tls-skip-verify ${unseal?} > /dev/null
+    bao login -no-print -tls-skip-verify ${root?} > /dev/null
     echo "Successfully bootstrapped openbao"


### PR DESCRIPTION
- changes .release files to reference openbao instead of hashicorp and openbao instead of vault
- fixes tests to return successfully
- updates the version of all the GHA workflow jobs

We have an empty docker repo now here:
https://quay.io/repository/openbao/openbao-csi-provider