### PR TITLE
chore(actions): bump hashicorp/actions-docker-build to v2.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
+        uses: hashicorp/actions-docker-build@200254326a30d7b747745592f8f4d226bbe4abe4 # v2.2.0
         with:
           version: ${{env.version}}
           target: default


### PR DESCRIPTION
This should fix the failing pipelines regarding deprecated `actions/download-artifact`