### PR TITLE
ci: update dependencies and kind-k8s versions in tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,9 +3,9 @@ name: Tests
 on: [push, workflow_dispatch, pull_request]
 
 env:
-  KIND_VERSION: "v0.23.0"
-  BATS_VERSION: "1.11.0"
-  NODE_VERSION: "22.0.0"
+  KIND_VERSION: "v0.29.0"
+  BATS_VERSION: "1.12.0"
+  NODE_VERSION: "24.2.0"
   TARBALL_FILE: openbao-csi-provider.docker.tar
 
 jobs:
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.27.13, 1.28.9, 1.29.4]
+        kind-k8s-version: [1.31.9, 1.32.5, 1.33.1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6


### PR DESCRIPTION
### Changed
- Updated KIND_VERSION from `v0.23.0` to `v0.29.0`.
- Updated BATS_VERSION from `1.11.0` to `1.12.0`.
- Updated NODE_VERSION from `22.0.0` to `24.2.0`.
- Modified kind-k8s-version matrix in CI tests workflow to include versions `1.31.9`, `1.32.5`, and `1.33.1` instead of `1.27.13`, `1.28.9`, and `1.29.4`.

