### PR TITLE
ci(gorleaser): set id

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,8 @@ before:
     - go generate ./...
 
 builds:
-  - env:
+  - id: builds-linux
+    env:
       - CGO_ENABLED=0
     goos:
       - linux


### PR DESCRIPTION
Adds the `id: builds-linux` to the goreleaser