### PR TITLE
ci(goreleaser): default arch is only amd64/arm64/386

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,10 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
 
 dockers:
   - id: alpine-amd64


### PR DESCRIPTION
Need to explicitly set also arm if we wanna build arm