### PR TITLE
ci(dependabot): group PR & cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directories:
       - "/"
       - "/.github/actions/*"
+    groups:
+      actions:
+        patterns:
+          - "*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directory: "/"
+    groups:
+      actions:
+        patterns:
+          - "*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
* Recent events show us it is good practice to have a 7 day cooldown before new updates are pushed to the repo, even as a branch.
* This PR also incorporates grouping of ci & gomod deps
