### PR TITLE
fix(ci): rename gomod group to `go-deps`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     groups:
-      actions:
+      go-deps:
         patterns:
           - "*"
     schedule:


### PR DESCRIPTION
Renaming the group used for go-dependencies to `go-deps`, so that it's more clear in the PR title.