### PR TITLE
chore(actions): move go-checks in-tree

### DIFF
--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -1,0 +1,57 @@
+name: go checks
+
+on: [push, workflow_dispatch, pull_request]
+
+env:
+  GOFUMPT_VERSION: 14050252a6d591bb7a3f0167c925c3d6e6f9bdf8  # v0.10.0
+  GOFUMPT_EXCLUDE_PATTERNS: "vendor,pb.go"
+
+jobs:
+  gomod:
+    name: Check that go.mod and go.sum are tidy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: .go-version
+      - name: Check go.mod and go.sum tidiness
+        run: |
+          go mod tidy
+          if [ ! -z "$(git status --porcelain go.mod go.sum)" ]; then
+            echo "Need to run 'go mod tidy'";
+            exit 1;
+          fi
+  gofumpt:
+    name: Check that code matches gofumpt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: .go-version
+      - name: Run gofumpt
+        run: |
+          echo "==> Install gofumpt ${{ env.GOFUMPT_VERSION }}"
+          go install mvdan.cc/gofumpt@${{ env.GOFUMPT_VERSION }}
+          echo "==> Checking that code complies with gofmt requirements..."
+
+          files=$(find . -name '*.go')
+          patterns='${{ env.GOFUMPT_EXCLUDE_PATTERNS }}'
+          OLDIFS=$IFS
+          IFS=","
+          for pattern in $patterns; do
+            files=$(echo $files | grep -v $pattern);
+          done
+          IFS=$OLDIFS
+          gofmt_files=$(gofmt -l $files)
+          if [[ -n ${gofmt_files} ]]; then
+              echo 'gofmt needs running on the following files:'
+              echo "${gofmt_files}"
+              echo "You can use the command: \`gofumpt -w\` to reformat them."
+              exit 1
+          fi

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -1,3 +1,6 @@
+# This file was originally sourced from:
+# https://github.com/hashicorp/vault-workflows-common/blob/main/.github/workflows/go-checks.y
+
 name: go checks
 
 on: [push, workflow_dispatch, pull_request]

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -6,7 +6,6 @@ name: go checks
 on: [push, workflow_dispatch, pull_request]
 
 env:
-  GOFUMPT_VERSION: 14050252a6d591bb7a3f0167c925c3d6e6f9bdf8  # v0.10.0
   GOFUMPT_EXCLUDE_PATTERNS: "vendor,pb.go"
 
 jobs:
@@ -39,8 +38,6 @@ jobs:
           go-version-file: .go-version
       - name: Run gofumpt
         run: |
-          echo "==> Install gofumpt ${{ env.GOFUMPT_VERSION }}"
-          go install mvdan.cc/gofumpt@${{ env.GOFUMPT_VERSION }}
           echo "==> Checking that code complies with gofmt requirements..."
 
           files=$(find . -name '*.go')
@@ -51,7 +48,7 @@ jobs:
             files=$(echo $files | grep -v $pattern);
           done
           IFS=$OLDIFS
-          gofmt_files=$(gofmt -l $files)
+          gofmt_files=$(go tool -modfile=tools/go.mod gofumpt -l $files)
           if [[ -n ${gofmt_files} ]]; then
               echo 'gofmt needs running on the following files:'
               echo "${gofmt_files}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,8 +9,6 @@ env:
   TARBALL_FILE: openbao-csi-provider.docker.tar
 
 jobs:
-  go-checks:
-    uses: hashicorp/vault-workflows-common/.github/workflows/go-checks.yaml@main
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/openbao/openbao-csi-provider/tools
 go 1.25.0
 
 tool (
-        github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	mvdan.cc/gofumpt
 )
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,6 +2,12 @@ module github.com/openbao/openbao-csi-provider/tools
 
 go 1.25.0
 
+tool (
+        github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/hashicorp/copywrite
+	mvdan.cc/gofumpt
+)
+
 require (
 	github.com/golangci/golangci-lint/v2 v2.1.6
 	github.com/hashicorp/copywrite v0.16.3
@@ -240,4 +246,3 @@ require (
 	mvdan.cc/unparam v0.0.0-20250301125049-0df0534333a4 // indirect
 )
 
-tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 tool (
         github.com/golangci/golangci-lint/v2/cmd/golangci-lint
-	github.com/hashicorp/copywrite
 	mvdan.cc/gofumpt
 )
 


### PR DESCRIPTION
Move `go-checks` GitHub actions in-tree to reduce external dependencies.

Origin: https://github.com/hashicorp/vault-workflows-common

---

Changes:
* pin `gofumpt` to it's sha instead of a mutable version number
* change to environment variables instead of `workflow_call.inputs` 